### PR TITLE
Fix go.mod module path

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	pb "github.com/Arize-ai/arize/sdk/go/receiver/protocol/public"
+	pb "github.com/Arize-ai/client_golang/receiver/protocol/public"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 

--- a/client_test.go
+++ b/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/Arize-ai/arize/sdk/go/receiver/protocol/public"
+	pb "github.com/Arize-ai/client_golang/receiver/protocol/public"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Arize-ai/arize/sdk/go
+module github.com/Arize-ai/client_golang
 
 go 1.17
 


### PR DESCRIPTION
```
(base) (⎈ |prod:arize-prod)➜  core git:(master) ✗ go get github.com/Arize-ai/client_golang@903d2c876c9b671cfff4632b929d2f91c439746b
go: downloading github.com/Arize-ai/client_golang v0.0.0-20220622225726-903d2c876c9b
go: downloading github.com/golang/protobuf v1.5.0
go get: added github.com/Arize-ai/client_golang v0.0.0-20220622225726-903d2c876c9b
go get: upgraded github.com/golang/protobuf v1.3.5 => v1.5.0
go get: upgraded github.com/stretchr/testify v1.5.1 => v1.7.2
(base) (⎈ |prod:arize-prod)➜  core git:(master) ✗
```